### PR TITLE
Fixed signal UP to DOWN bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,8 +132,8 @@ class MojoHelpdesk extends q.DesktopApp {
         });
         this.updateUrlWithRightTime();
         logger.info("serviceUrl AFTER UPDATE in run function: " + this.serviceUrl);
-        return signal;
       }
+      return signal;
     }
     catch (error) {
       logger.error(`Got error sending request to service: ${JSON.stringify(error)}`);


### PR DESCRIPTION
When we install the app with no unassigned ticket: key is OK (black)
When new unassigned ticket, key is with the good signal (defined in config)
But when ticket was assigned and no unassigned ticket remaining, key still with alert signal.
This fix return null if no unassigned ticket.